### PR TITLE
Hide blank/empty fields in preview mode and PDF downloads

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -109,9 +109,9 @@ function Certifications() {
             <div className="certification-display">
               <div className="cert-header">
                 <h3 className="cert-name">{cert.name}</h3>
-                <span className="cert-date">{cert.date}</span>
+                {cert.date && <span className="cert-date">{cert.date}</span>}
               </div>
-              <p className="cert-issuer">{cert.issuer}</p>
+              {cert.issuer && <p className="cert-issuer">{cert.issuer}</p>}
               {cert.credentialId && (
                 <p className="cert-credential">
                   <span className="cert-credential-label">Credential ID:</span> {cert.credentialId}

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -61,7 +61,7 @@ function Education() {
               <h3 className="degree">{edu.degree}</h3>
               <p className="school">{edu.school}</p>
               <p className="date">{edu.date}</p>
-              <p className="description">{edu.details}</p>
+              {edu.details && <p className="description">{edu.details}</p>}
             </>
           )}
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -77,17 +77,25 @@ function Header() {
       <h1 className="name">{personal.name}</h1>
       <p className="title">{personal.title}</p>
       <div className="contact-info">
-        <span>{personal.email}</span>
-        <span>•</span>
-        <span>{personal.phone}</span>
-        <span>•</span>
-        <span>{personal.location}</span>
+        {personal.email && <span>{personal.email}</span>}
+        {personal.email && personal.phone && <span>•</span>}
+        {personal.phone && <span>{personal.phone}</span>}
+        {(personal.email || personal.phone) && personal.location && <span>•</span>}
+        {personal.location && <span>{personal.location}</span>}
       </div>
-      <div className="social-links">
-        <a href={personal.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn</a>
-        <a href={personal.github} target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href={personal.portfolio} target="_blank" rel="noopener noreferrer">Portfolio</a>
-      </div>
+      {(personal.linkedin || personal.github || personal.portfolio) && (
+        <div className="social-links">
+          {personal.linkedin && (
+            <a href={personal.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+          )}
+          {personal.github && (
+            <a href={personal.github} target="_blank" rel="noopener noreferrer">GitHub</a>
+          )}
+          {personal.portfolio && (
+            <a href={personal.portfolio} target="_blank" rel="noopener noreferrer">Portfolio</a>
+          )}
+        </div>
+      )}
     </header>
   )
 }

--- a/src/services/pdfDownloadService.js
+++ b/src/services/pdfDownloadService.js
@@ -54,8 +54,16 @@ export function downloadResumePDF(resumeData) {
   pdf.text(resumeData.personal.title, margin, 23)
 
   pdf.setFontSize(9)
-  const contactLine = `${resumeData.personal.email} • ${resumeData.personal.phone} • ${resumeData.personal.location}`
-  pdf.text(contactLine, margin, 30)
+  const contactParts = [
+    resumeData.personal.email,
+    resumeData.personal.phone,
+    resumeData.personal.location
+  ].filter(Boolean)
+
+  if (contactParts.length > 0) {
+    const contactLine = contactParts.join(' • ')
+    pdf.text(contactLine, margin, 30)
+  }
 
   const linksLine = [
     resumeData.personal.linkedin && 'LinkedIn',
@@ -224,14 +232,22 @@ export function downloadResumePDF(resumeData) {
 
       // Issuer and Date
       pdf.setFontSize(10)
-      pdf.setFont('helvetica', 'italic')
-      pdf.setTextColor(52, 152, 219)
-      pdf.text(cert.issuer, margin, yPosition)
 
-      pdf.setFont('helvetica', 'normal')
-      pdf.setTextColor(127, 140, 141)
-      pdf.text(cert.date, pageWidth - margin - pdf.getTextWidth(cert.date), yPosition)
-      yPosition += 6
+      if (cert.issuer) {
+        pdf.setFont('helvetica', 'italic')
+        pdf.setTextColor(52, 152, 219)
+        pdf.text(cert.issuer, margin, yPosition)
+      }
+
+      if (cert.date) {
+        pdf.setFont('helvetica', 'normal')
+        pdf.setTextColor(127, 140, 141)
+        pdf.text(cert.date, pageWidth - margin - pdf.getTextWidth(cert.date), yPosition)
+      }
+
+      if (cert.issuer || cert.date) {
+        yPosition += 6
+      }
 
       // Credential ID
       if (cert.credentialId) {


### PR DESCRIPTION
Feature Enhancement:
- Empty or blank fields now automatically hide in preview mode
- PDF downloads no longer show empty fields
- Cleaner, more professional resume output

Changes Made:

1. Header Component (Header.jsx):
   - Contact info (email, phone, location) only shows if filled
   - Bullet separators (•) only appear between filled fields
   - Social links section (LinkedIn, GitHub, Portfolio) only shows if at least one link exists
   - Individual social links only appear if URLs are provided

2. Education Component (Education.jsx):
   - Details field only shows if content exists
   - Prevents empty paragraphs in preview mode

3. Certifications Component (Certifications.jsx):
   - Date only shows if provided
   - Issuer only shows if provided
   - Credential ID and URL already had conditional rendering (kept)

4. PDF Download Service (pdfDownloadService.js):
   - Contact line only includes filled fields (email, phone, location)
   - Links line only shows if at least one link exists
   - Certification issuer and date only render if provided
   - Proper spacing adjustment when fields are empty

Examples:
- If LinkedIn is blank, only GitHub and Portfolio show
- If phone is blank, only email and location show (no orphan bullets)
- If certification date is blank, only name and issuer show

Benefits:
- Cleaner preview mode with no empty fields
- Professional PDF output without blank lines
- Dynamic layout adjusts to filled content only
- Better user experience - what you fill is what you see