### PR TITLE
Fix: Properly hide blank fields with .trim() check for whitespace

### DIFF
--- a/src/components/Certifications.jsx
+++ b/src/components/Certifications.jsx
@@ -108,16 +108,16 @@ function Certifications() {
           ) : (
             <div className="certification-display">
               <div className="cert-header">
-                <h3 className="cert-name">{cert.name}</h3>
-                {cert.date && <span className="cert-date">{cert.date}</span>}
+                {cert.name?.trim() && <h3 className="cert-name">{cert.name}</h3>}
+                {cert.date?.trim() && <span className="cert-date">{cert.date}</span>}
               </div>
-              {cert.issuer && <p className="cert-issuer">{cert.issuer}</p>}
-              {cert.credentialId && (
+              {cert.issuer?.trim() && <p className="cert-issuer">{cert.issuer}</p>}
+              {cert.credentialId?.trim() && (
                 <p className="cert-credential">
                   <span className="cert-credential-label">Credential ID:</span> {cert.credentialId}
                 </p>
               )}
-              {cert.credentialUrl && (
+              {cert.credentialUrl?.trim() && (
                 <p className="cert-url">
                   <a
                     href={cert.credentialUrl}

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -58,10 +58,10 @@ function Education() {
             </div>
           ) : (
             <>
-              <h3 className="degree">{edu.degree}</h3>
-              <p className="school">{edu.school}</p>
-              <p className="date">{edu.date}</p>
-              {edu.details && <p className="description">{edu.details}</p>}
+              {edu.degree?.trim() && <h3 className="degree">{edu.degree}</h3>}
+              {edu.school?.trim() && <p className="school">{edu.school}</p>}
+              {edu.date?.trim() && <p className="date">{edu.date}</p>}
+              {edu.details?.trim() && <p className="description">{edu.details}</p>}
             </>
           )}
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -77,21 +77,21 @@ function Header() {
       <h1 className="name">{personal.name}</h1>
       <p className="title">{personal.title}</p>
       <div className="contact-info">
-        {personal.email && <span>{personal.email}</span>}
-        {personal.email && personal.phone && <span>•</span>}
-        {personal.phone && <span>{personal.phone}</span>}
-        {(personal.email || personal.phone) && personal.location && <span>•</span>}
-        {personal.location && <span>{personal.location}</span>}
+        {personal.email?.trim() && <span>{personal.email}</span>}
+        {personal.email?.trim() && personal.phone?.trim() && <span>•</span>}
+        {personal.phone?.trim() && <span>{personal.phone}</span>}
+        {(personal.email?.trim() || personal.phone?.trim()) && personal.location?.trim() && <span>•</span>}
+        {personal.location?.trim() && <span>{personal.location}</span>}
       </div>
-      {(personal.linkedin || personal.github || personal.portfolio) && (
+      {(personal.linkedin?.trim() || personal.github?.trim() || personal.portfolio?.trim()) && (
         <div className="social-links">
-          {personal.linkedin && (
+          {personal.linkedin?.trim() && (
             <a href={personal.linkedin} target="_blank" rel="noopener noreferrer">LinkedIn</a>
           )}
-          {personal.github && (
+          {personal.github?.trim() && (
             <a href={personal.github} target="_blank" rel="noopener noreferrer">GitHub</a>
           )}
-          {personal.portfolio && (
+          {personal.portfolio?.trim() && (
             <a href={personal.portfolio} target="_blank" rel="noopener noreferrer">Portfolio</a>
           )}
         </div>

--- a/src/services/pdfDownloadService.js
+++ b/src/services/pdfDownloadService.js
@@ -55,9 +55,9 @@ export function downloadResumePDF(resumeData) {
 
   pdf.setFontSize(9)
   const contactParts = [
-    resumeData.personal.email,
-    resumeData.personal.phone,
-    resumeData.personal.location
+    resumeData.personal.email?.trim(),
+    resumeData.personal.phone?.trim(),
+    resumeData.personal.location?.trim()
   ].filter(Boolean)
 
   if (contactParts.length > 0) {
@@ -66,9 +66,9 @@ export function downloadResumePDF(resumeData) {
   }
 
   const linksLine = [
-    resumeData.personal.linkedin && 'LinkedIn',
-    resumeData.personal.github && 'GitHub',
-    resumeData.personal.portfolio && 'Portfolio'
+    resumeData.personal.linkedin?.trim() && 'LinkedIn',
+    resumeData.personal.github?.trim() && 'GitHub',
+    resumeData.personal.portfolio?.trim() && 'Portfolio'
   ].filter(Boolean).join(' • ')
 
   if (linksLine) {
@@ -233,24 +233,24 @@ export function downloadResumePDF(resumeData) {
       // Issuer and Date
       pdf.setFontSize(10)
 
-      if (cert.issuer) {
+      if (cert.issuer?.trim()) {
         pdf.setFont('helvetica', 'italic')
         pdf.setTextColor(52, 152, 219)
         pdf.text(cert.issuer, margin, yPosition)
       }
 
-      if (cert.date) {
+      if (cert.date?.trim()) {
         pdf.setFont('helvetica', 'normal')
         pdf.setTextColor(127, 140, 141)
         pdf.text(cert.date, pageWidth - margin - pdf.getTextWidth(cert.date), yPosition)
       }
 
-      if (cert.issuer || cert.date) {
+      if (cert.issuer?.trim() || cert.date?.trim()) {
         yPosition += 6
       }
 
       // Credential ID
-      if (cert.credentialId) {
+      if (cert.credentialId?.trim()) {
         pdf.setFontSize(9)
         pdf.setFont('helvetica', 'normal')
         pdf.setTextColor(85, 85, 85)
@@ -260,7 +260,7 @@ export function downloadResumePDF(resumeData) {
       }
 
       // Credential URL (if exists)
-      if (cert.credentialUrl) {
+      if (cert.credentialUrl?.trim()) {
         pdf.setFontSize(9)
         pdf.setFont('helvetica', 'normal')
         pdf.setTextColor(52, 152, 219)


### PR DESCRIPTION
Bug Fix:
- Fixed issue where fields with empty strings or whitespace still appeared in preview/PDF
- Added .trim() check to all conditional field rendering
- Now properly handles empty strings (""), whitespace ("   "), null, and undefined

Root Cause:
- Empty strings "" are falsy in JavaScript and should work with &&
- However, whitespace-only strings like "   " are truthy
- Fields were appearing in preview/PDF if they contained only spaces
- Need explicit .trim() check to handle all edge cases

Changes Made:

1. Header.jsx:
   - Added .trim() to all contact fields (email, phone, location)
   - Added .trim() to all social links (LinkedIn, GitHub, Portfolio)
   - Used optional chaining (?.) for safety
   - Bullet separators now properly hide if adjacent fields are blank/whitespace

2. Education.jsx:
   - Added .trim() to degree, school, date, and details fields
   - Each field independently checks if it has content before rendering

3. Certifications.jsx:
   - Added .trim() to name, date, issuer, credentialId, credentialUrl
   - All optional fields properly hide when blank/whitespace

4. PDF Service (pdfDownloadService.js):
   - Added .trim() to contact parts array (email, phone, location)
   - Added .trim() to social links check
   - Added .trim() to all certification fields
   - PDF now perfectly matches preview mode

Examples Fixed:
- LinkedIn field with just spaces: Now hidden ✅
- Phone field = "": No orphan bullet ✅
- Location with whitespace: Properly hidden ✅
- Certification date blank: Only shows name and issuer ✅

Testing:
- Tested with empty strings, whitespace, null, and undefined
- Verified preview mode matches PDF output
- Confirmed no orphan bullets or empty sections